### PR TITLE
Changes to support gemma3 vision encoder for maya 2.0. 

### DIFF
--- a/llava/model/multimodal_encoder/builder.py
+++ b/llava/model/multimodal_encoder/builder.py
@@ -11,6 +11,6 @@ def build_vision_tower(vision_tower_cfg, **kwargs):
             return CLIPVisionTowerS2(vision_tower, args=vision_tower_cfg, **kwargs)
         else:
             return CLIPVisionTower(vision_tower, args=vision_tower_cfg, **kwargs)
-    elif 'siglip' in vision_tower:
+    elif 'siglip' in vision_tower or 'gemma' in vision_tower:
         return SiglipVisionTower(vision_tower, args=vision_tower_cfg, **kwargs)
     raise ValueError(f'Unknown vision tower: {vision_tower}')

--- a/scripts/maya/pretrain_aya_gemma_siglip.sh
+++ b/scripts/maya/pretrain_aya_gemma_siglip.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+
+MODEL_VERSION=aya-23-8b-siglip-multi
+
+########### DO NOT CHANGE ###########
+########### USE THIS FOR BOTH ###########
+PROMPT_VERSION=plain
+########### DO NOT CHANGE ###########
+
+deepspeed llava/train/train_mem.py \
+    --deepspeed ./scripts/zero2.json \
+    --model_name_or_path CohereForAI/aya-23-8B \
+    --version $PROMPT_VERSION \
+    --data_path /dev/data/LLaVA_Pretrain \
+    --image_folder /dev/data/images \
+    --vision_tower SatyaV/gemma-3-4b-SiglipEncoder \
+    --mm_projector_type mlp2x_gelu \
+    --tune_mm_mlp_adapter True \
+    --mm_vision_select_layer -2 \
+    --mm_use_im_start_end False \
+    --mm_use_im_patch_token False \
+    --bf16 True \
+    --output_dir ./checkpoints/llava-$MODEL_VERSION-pretrain \
+    --num_train_epochs 1 \
+    --per_device_train_batch_size 4 \
+    --per_device_eval_batch_size 4 \
+    --gradient_accumulation_steps 8 \
+    --evaluation_strategy "no" \
+    --save_strategy "steps" \
+    --save_steps 24000 \
+    --save_total_limit 1 \
+    --learning_rate 1e-3 \
+    --weight_decay 0. \
+    --warmup_ratio 0.03 \
+    --lr_scheduler_type "cosine" \
+    --logging_steps 1 \
+    --tf32 True \
+    --model_max_length 2048 \
+    --gradient_checkpointing True \
+    --dataloader_num_workers 4 \
+    --lazy_preprocess True \
+    --report_to wandb


### PR DESCRIPTION
For now had to extract the gemm3-vision_encoder as the latest stable transofmers version does not have gemma3 models supported yet. For now we could use SatyaV/gemma-3-4b-SiglipEncoder for our dev and once we have transformers with gemma3 we can make changes to pull directly from gemma3 models.